### PR TITLE
[DC-41] Make SideNavigationBar component

### DIFF
--- a/src/components/SideNavigation/index.tsx
+++ b/src/components/SideNavigation/index.tsx
@@ -1,0 +1,38 @@
+import { Dispatch, SetStateAction } from 'react';
+
+import * as S from './styled';
+
+type Props = {
+  title: string;
+  navigations: string[];
+  selected: string;
+  setSelected: Dispatch<SetStateAction<string>>;
+};
+
+export default function SideNavigation({
+  title,
+  navigations,
+  selected,
+  setSelected,
+}: Props) {
+  const onClickNavigation = (item: string) => setSelected(item);
+
+  return (
+    <S.Layout>
+      <S.Title>{title}</S.Title>
+      <div>
+        {navigations.map((item, index) => {
+          return (
+            <S.NavigationWrapper
+              key={index}
+              isSelected={item === selected}
+              onClick={() => onClickNavigation(item)}
+            >
+              {item}
+            </S.NavigationWrapper>
+          );
+        })}
+      </div>
+    </S.Layout>
+  );
+}

--- a/src/components/SideNavigation/styled.ts
+++ b/src/components/SideNavigation/styled.ts
@@ -1,0 +1,42 @@
+import styled, { css } from 'styled-components';
+
+import { Body1, Body2 } from '../../styles/common';
+
+export const Layout = styled.div`
+  width: 184px;
+`;
+
+interface NavigationWrapperProps {
+  isSelected: boolean;
+}
+
+export const Title = styled.p`
+  color: ${({ theme }) => theme.colors.gray3};
+  margin: 0 0 8px 0;
+
+  ${Body1};
+`;
+
+export const NavigationWrapper = styled.button<NavigationWrapperProps>`
+  cursor: pointer;
+  border: none;
+  padding: 10px 16px;
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+
+  border-radius: ${({ theme }) => theme.radius.sm};
+
+  ${({ isSelected, theme }) =>
+    isSelected
+      ? css`
+          background-color: ${theme.colors.gray1};
+          color: ${theme.colors.black};
+        `
+      : css`
+          background-color: ${theme.colors.white};
+          color: ${theme.colors.gray3};
+        `};
+
+  ${Body2}
+`;

--- a/src/components/SideNavigation/styled.ts
+++ b/src/components/SideNavigation/styled.ts
@@ -6,10 +6,6 @@ export const Layout = styled.div`
   width: 184px;
 `;
 
-interface NavigationWrapperProps {
-  isSelected: boolean;
-}
-
 export const Title = styled.p`
   color: ${({ theme }) => theme.colors.gray3};
   margin: 0 0 8px 0;
@@ -17,13 +13,17 @@ export const Title = styled.p`
   ${Body1};
 `;
 
+interface NavigationWrapperProps {
+  isSelected: boolean;
+}
+
 export const NavigationWrapper = styled.button<NavigationWrapperProps>`
-  cursor: pointer;
-  border: none;
-  padding: 10px 16px;
-  width: 100%;
   display: flex;
   justify-content: flex-start;
+  padding: 10px 16px;
+  width: 100%;
+  border: none;
+  cursor: pointer;
 
   border-radius: ${({ theme }) => theme.radius.sm};
 


### PR DESCRIPTION
### 📃 변경사항
- SideNavigationBar 컴포넌트 생성
- title, navigations, selected, setSelected을 props로 받습니다.
- navigations는 문자열 배열 형식이며, 네비게이션 목록들을 받습니다.
- selected와 setSelected는 useState입니다.

### 📌 중점적으로 볼 부분
props 부분 수정할 게 있다면 알려주세요.

### 🎇 스크린샷
<img width="207" alt="image" src="https://user-images.githubusercontent.com/80266418/217573664-15e266f1-3a2c-451e-8088-1456db687ec2.png">


### 💫 기타사항
