### PR TITLE
[DC-50] Make SubTopNavigation

### DIFF
--- a/src/components/SideNavigation/index.tsx
+++ b/src/components/SideNavigation/index.tsx
@@ -23,13 +23,13 @@ export default function SideNavigation({
       <div>
         {navigations.map((item, index) => {
           return (
-            <S.NavigationWrapper
+            <S.NavigationButton
               key={index}
               isSelected={item === selected}
               onClick={() => onClickNavigation(item)}
             >
               {item}
-            </S.NavigationWrapper>
+            </S.NavigationButton>
           );
         })}
       </div>

--- a/src/components/SideNavigation/index.tsx
+++ b/src/components/SideNavigation/index.tsx
@@ -4,14 +4,14 @@ import * as S from './styled';
 
 type Props = {
   title: string;
-  navigations: string[];
+  navigationList: string[];
   selected: string;
   setSelected: Dispatch<SetStateAction<string>>;
 };
 
 export default function SideNavigation({
   title,
-  navigations,
+  navigationList,
   selected,
   setSelected,
 }: Props) {
@@ -21,7 +21,7 @@ export default function SideNavigation({
     <S.Layout>
       <S.Title>{title}</S.Title>
       <div>
-        {navigations.map((item, index) => {
+        {navigationList.map((item, index) => {
           return (
             <S.NavigationButton
               key={index}

--- a/src/components/SideNavigation/styled.ts
+++ b/src/components/SideNavigation/styled.ts
@@ -13,11 +13,11 @@ export const Title = styled.p`
   ${Body1};
 `;
 
-interface NavigationWrapperProps {
+interface NavigationButtonProps {
   isSelected: boolean;
 }
 
-export const NavigationWrapper = styled.button<NavigationWrapperProps>`
+export const NavigationButton = styled.button<NavigationButtonProps>`
   display: flex;
   justify-content: flex-start;
   padding: 10px 16px;

--- a/src/pages/postlist/SubTopNavigation/index.tsx
+++ b/src/pages/postlist/SubTopNavigation/index.tsx
@@ -1,0 +1,33 @@
+import { Dispatch, SetStateAction } from 'react';
+
+import * as S from './styled';
+
+type Props = {
+  navigationList: string[];
+  selected: string;
+  setSelected: Dispatch<SetStateAction<string>>;
+};
+
+export default function SubTopNavigation({
+  navigationList,
+  selected,
+  setSelected,
+}: Props) {
+  const onClickNavigation = (item: string) => setSelected(item);
+
+  return (
+    <S.Layout>
+      {navigationList.map((item, index) => {
+        return (
+          <S.NavigationButton
+            key={index}
+            isSelected={item === selected}
+            onClick={() => onClickNavigation(item)}
+          >
+            {item}
+          </S.NavigationButton>
+        );
+      })}
+    </S.Layout>
+  );
+}

--- a/src/pages/postlist/SubTopNavigation/styled.ts
+++ b/src/pages/postlist/SubTopNavigation/styled.ts
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+import { Body1 } from '../../../styles/common';
+
+export const Layout = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  border-bottom: ${({ theme }) => `1px solid ${theme.colors.gray2}`};
+`;
+
+interface NavigationButtonProps {
+  isSelected: boolean;
+}
+
+export const NavigationButton = styled.div<NavigationButtonProps>`
+  padding: 12px;
+  cursor: pointer;
+  color: ${({ theme, isSelected }) => theme.colors[isSelected ? 'black' : 'gray3']};
+
+  ${Body1};
+  font-weight: ${({ isSelected }) => (isSelected ? 700 : 500)};
+`;


### PR DESCRIPTION
### 📃 변경사항
- 전체 글 모아보기 페이지의 SubTopNavigation 컴포넌트 제작
- 글 순서를 변경하는 데 사용됩니다.
- SideNavigation과 비슷하게 navigationList와, 선택된 요소와 관련된 useState인 selected, setSelected를 props로 받습니다. 

### 📌 중점적으로 볼 부분
- 이 페이지에서만 쓸 것 같아서 일단 postlist 폴더 안에 넣었는데, 다른 데에도 필요할 것 같으면 옮기겠습니다. 

### 🎇 스크린샷
<img width="539" alt="image" src="https://user-images.githubusercontent.com/80266418/217787477-204074ef-c426-42d5-aac2-98b6d7b62803.png">


### 💫 기타사항
